### PR TITLE
tape-like scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
         }
       }
 
-      #offsetControl {
+      #positionControl {
         position: absolute;
         bottom: 20px;
         left: 50%;
@@ -97,12 +97,12 @@
         z-index: 10;
       }
       
-      #offsetSlider {
+      #positionSlider {
         width: 200px;
         margin-right: 10px;
       }
       
-      #offsetValue {
+      #positionSliderValue {
         font-family: monospace;
         min-width: 45px;
         text-align: right;
@@ -116,11 +116,11 @@
           left: 15px;
         }
         
-        #offsetControl {
+        #positionControl {
           padding: 6px 10px;
         }
         
-        #offsetSlider {
+        #positionSlider {
           width: 150px;
         }
       }
@@ -131,9 +131,9 @@
       <canvas id="waveformCanvas"></canvas>
       <div id="playhead"></div>
       <button id="recordButton" title="Record Audio"></button>
-      <div id="offsetControl">
-        <input type="range" id="offsetSlider" min="0" max="1" step="0.01" value="0" autocomplete="off">
-        <span id="offsetValue">0</span>
+      <div id="positionControl">
+        <input type="range" id="positionSlider" min="0" max="1" step="0.01" value="0" autocomplete="off">
+        <span id="positionSliderValue">0</span>
       </div>
     </div>
     <script type="module" src="./src/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         touch-action: none;
         user-select: none;
         -webkit-user-drag: none;
-        -webkit-user-select: none; 
+        -webkit-user-select: none;
         -moz-user-select: none;
         -ms-user-select: none;
         pointer-events: auto;
@@ -96,18 +96,18 @@
         border-radius: 20px;
         z-index: 10;
       }
-      
+
       #positionSlider {
         width: 200px;
         margin-right: 10px;
       }
-      
+
       #positionSliderValue {
         font-family: monospace;
         min-width: 45px;
         text-align: right;
       }
-      
+
       @media (max-width: 768px) {
         #recordButton {
           width: 50px;
@@ -115,11 +115,11 @@
           top: 15px;
           left: 15px;
         }
-        
+
         #positionControl {
           padding: 6px 10px;
         }
-        
+
         #positionSlider {
           width: 150px;
         }
@@ -132,7 +132,15 @@
       <div id="playhead"></div>
       <button id="recordButton" title="Record Audio"></button>
       <div id="positionControl">
-        <input type="range" id="positionSlider" min="0" max="1" step="0.01" value="0" autocomplete="off">
+        <input
+          type="range"
+          id="positionSlider"
+          min="0"
+          max="1"
+          step="0.01"
+          value="0"
+          autocomplete="off"
+        />
         <span id="positionSliderValue">0</span>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
       <div id="playhead"></div>
       <button id="recordButton" title="Record Audio"></button>
       <div id="offsetControl">
-        <input type="range" id="offsetSlider" min="-1" max="1" step="0.01" value="0" autocomplete="off">
+        <input type="range" id="offsetSlider" min="0" max="1" step="0.01" value="0" autocomplete="off">
         <span id="offsetValue">0</span>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -132,7 +132,7 @@
       <button id="recordButton" title="Record Audio"></button>
       <div id="offsetControl">
         <input type="range" id="offsetSlider" min="-1" max="1" step="0.01" value="0">
-        <span id="offsetValue">0.00</span>
+        <span id="offsetValue">0</span>
       </div>
     </div>
     <script type="module" src="./src/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
       <div id="playhead"></div>
       <button id="recordButton" title="Record Audio"></button>
       <div id="offsetControl">
-        <input type="range" id="offsetSlider" min="-1" max="1" step="0.01" value="0">
+        <input type="range" id="offsetSlider" min="-1" max="1" step="0.01" value="0" autocomplete="off">
         <span id="offsetValue">0</span>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -83,12 +83,44 @@
         }
       }
 
+      #offsetControl {
+        position: absolute;
+        bottom: 20px;
+        left: 50%;
+        transform: translateX(-50%);
+        display: flex;
+        align-items: center;
+        background-color: rgba(255, 255, 255, 0.8);
+        padding: 8px 15px;
+        border-radius: 20px;
+        z-index: 10;
+      }
+      
+      #offsetSlider {
+        width: 200px;
+        margin-right: 10px;
+      }
+      
+      #offsetValue {
+        font-family: monospace;
+        min-width: 45px;
+        text-align: right;
+      }
+      
       @media (max-width: 768px) {
         #recordButton {
           width: 50px;
           height: 50px;
           top: 15px;
           left: 15px;
+        }
+        
+        #offsetControl {
+          padding: 6px 10px;
+        }
+        
+        #offsetSlider {
+          width: 150px;
         }
       }
     </style>
@@ -98,6 +130,10 @@
       <canvas id="waveformCanvas"></canvas>
       <div id="playhead"></div>
       <button id="recordButton" title="Record Audio"></button>
+      <div id="offsetControl">
+        <input type="range" id="offsetSlider" min="-1" max="1" step="0.01" value="0">
+        <span id="offsetValue">0.00</span>
+      </div>
     </div>
     <script type="module" src="./src/main.js"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -32,11 +32,12 @@
       #playhead {
         position: absolute;
         top: 0;
-        left: 0;
+        left: 50%;
         width: 2px;
         height: 100%;
         background-color: red;
-        transform: translateX(0);
+        z-index: 10;
+        pointer-events: none;
       }
       #recordButton {
         position: absolute;

--- a/src/main.js
+++ b/src/main.js
@@ -12,8 +12,9 @@ let mediaRecorder;
 let recordedChunks = [];
 let isRecording = false;
 
+let currentPosition = 0;
 let isInteracting = false;
-let dragStartX = null;
+let lastX = null;
 
 document.addEventListener('dragover', (event) => { event.preventDefault(); });
 document.addEventListener('drop', handleDrop);
@@ -165,24 +166,26 @@ function handleRecordButtonTouch(event) {
 
 function beginInteraction(x) {
     isInteracting = true;
-    dragStartX = x;
+    lastX = x;
     if (audioContext && audioContext.state === 'suspended') {
         audioContext.resume();
     }
 }
 
 function handleInteraction(x, width) {
-    const startPosition = dragStartX / width;
+    const lastPosition = Math.max(0, Math.min(1, lastX / width));
     const position = Math.max(0, Math.min(1, x / width));
+    const offset = lastPosition - position;
+    currentPosition += offset;
 
-    // samplerNode.port.postMessage({
-    //     action: 'updatePosition',
-    //     position: position
-    // });
+    samplerNode.port.postMessage({
+        action: 'updatePosition',
+        position: currentPosition
+    });
 
-    const offset = startPosition - position;
-    offsetValue.textContent = offset.toFixed(2);
-    waveform.plot(audioBuffer, offset);
+    offsetValue.textContent = currentPosition.toFixed(2);
+    waveform.plot(audioBuffer, currentPosition);
+    lastX = x;
 }
 
 function handleMouseDown(event) {

--- a/src/main.js
+++ b/src/main.js
@@ -214,8 +214,6 @@ function updateWaveformPosition(x, width) {
         action: 'updatePosition',
         position: position
     });
-
-    waveform.updatePlayhead(position);
 }
 
 function handleOffsetChange(event) {

--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ const positionSliderValue = document.getElementById('positionSliderValue');
 positionSlider.addEventListener('input', handlePositionSliderChange);
 
 document.getElementById(WAVEFORM_CANVAS_ID).addEventListener('mousedown', handleMouseDown);
-document.getElementById(WAVEFORM_CANVAS_ID).addEventListener('mousemove', handleWaveformMouseMove);
+document.getElementById(WAVEFORM_CANVAS_ID).addEventListener('mousemove', handleMouseMove);
 document.addEventListener('mouseup', handleMouseUp); // pick up mouseUp anywhere
 
 document.getElementById(WAVEFORM_CANVAS_ID).addEventListener('touchstart', handleTouchStart);
@@ -222,7 +222,7 @@ function handleMouseUp(event) {
     isInteracting = false;
 }
 
-function handleWaveformMouseMove(event) {
+function handleMouseMove(event) {
     if (!audioBuffer || !isInteracting) return;
 
     const rect = event.target.getBoundingClientRect();

--- a/src/main.js
+++ b/src/main.js
@@ -170,7 +170,7 @@ function handlePositionSliderChange(event) {
         audioContext.resume();
     }
 
-    const currentPosition = parseFloat(event.target.value);
+    currentPosition = parseFloat(event.target.value);
     positionSliderValue.textContent = currentPosition.toFixed(2);
 
     samplerNode.port.postMessage({

--- a/src/main.js
+++ b/src/main.js
@@ -177,6 +177,15 @@ function handleMouseUp(event) {
     isInteracting = false;
 }
 
+function handleWaveformMouseMove(event) {
+    if (!audioBuffer || !isInteracting) return;
+
+    const rect = event.target.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+
+    handleInteraction(x, rect.width);
+}
+
 function handleTouchStart(event) {
     event.preventDefault();
     beginInteraction();
@@ -194,15 +203,6 @@ function handleTouchMove(event) {
     const touch = event.touches[0];
     const rect = event.target.getBoundingClientRect();
     const x = touch.clientX - rect.left;
-
-    handleInteraction(x, rect.width);
-}
-
-function handleWaveformMouseMove(event) {
-    if (!audioBuffer || !isInteracting) return;
-
-    const rect = event.target.getBoundingClientRect();
-    const x = event.clientX - rect.left;
 
     handleInteraction(x, rect.width);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -195,7 +195,7 @@ function handleTouchMove(event) {
     const rect = event.target.getBoundingClientRect();
     const x = touch.clientX - rect.left;
 
-    updateWaveformPosition(x, rect.width);
+    handleInteraction(x, rect.width);
 }
 
 function handleWaveformMouseMove(event) {
@@ -204,10 +204,10 @@ function handleWaveformMouseMove(event) {
     const rect = event.target.getBoundingClientRect();
     const x = event.clientX - rect.left;
 
-    updateWaveformPosition(x, rect.width);
+    handleInteraction(x, rect.width);
 }
 
-function updateWaveformPosition(x, width) {
+function handleInteraction(x, width) {
     const position = Math.max(0, Math.min(1, x / width));
 
     samplerNode.port.postMessage({

--- a/src/main.js
+++ b/src/main.js
@@ -64,6 +64,9 @@ async function handleDrop(event) {
                 buffer: channelData.buffer
             }, [channelData.buffer.slice()]);
         }
+        currentPosition = 0;
+        positionSlider.value = currentPosition;
+        positionSliderValue.textContent = currentPosition.toFixed(2);
         waveform.plot(audioBuffer);
     };
 

--- a/src/main.js
+++ b/src/main.js
@@ -206,6 +206,7 @@ function handleInteraction(x, width) {
     });
 
     positionSliderValue.textContent = currentPosition.toFixed(2);
+    positionSlider.value = currentPosition.toFixed(2);
     waveform.plot(audioBuffer, currentPosition);
     lastX = x;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -7,17 +7,19 @@ let audioContext;
 let audioBuffer;
 let channelData;
 let samplerNode;
-let waveform;
+
 let mediaRecorder;
 let recordedChunks = [];
 let isRecording = false;
 
+let waveform;
 let isInteracting = false;
 let lastMouseX = null;
 let playheadPosition = 0;
 
 document.addEventListener('dragover', (event) => { event.preventDefault(); });
 document.addEventListener('drop', handleDrop);
+
 const recordButton = document.getElementById('recordButton');
 recordButton.addEventListener('click', toggleRecording);
 recordButton.addEventListener('touchstart', handleRecordButtonTouch);
@@ -33,7 +35,6 @@ document.addEventListener('mouseup', handleMouseUp); // pick up mouseUp anywhere
 document.getElementById(WAVEFORM_CANVAS_ID).addEventListener('touchstart', handleTouchStart);
 document.getElementById(WAVEFORM_CANVAS_ID).addEventListener('touchmove', handleTouchMove);
 document.addEventListener('touchend', handleTouchEnd); // pick up touchEnd anywhere
-
 document.getElementById(WAVEFORM_CANVAS_ID).addEventListener('dragstart', (event) => {
     event.preventDefault();
 });
@@ -58,12 +59,14 @@ async function handleDrop(event) {
         audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
         if (audioBuffer.numberOfChannels > 1) console.warn('Audio file has more than one channel, using the first channel only.');
         channelData = audioBuffer.getChannelData(0); // truncate to first channel for now
+
         if (samplerNode) {
             samplerNode.port.postMessage({
                 action: 'setBuffer',
                 buffer: channelData.buffer
             }, [channelData.buffer.slice()]);
         }
+
         playheadPosition = 0;
         positionSlider.value = playheadPosition;
         positionSliderValue.textContent = playheadPosition.toFixed(2);
@@ -112,29 +115,27 @@ async function toggleRecording() {
                     const recordedBuffer = await audioContext.decodeAudioData(arrayBuffer);
                     audioBuffer = recordedBuffer;
                     channelData = audioBuffer.getChannelData(0);
+
                     if (samplerNode) {
                         samplerNode.port.postMessage({
                             action: 'setBuffer',
                             buffer: channelData.buffer
                         }, [channelData.buffer.slice()]);
                     }
+
                     waveform.plot(audioBuffer);
                 } catch (error) {
                     console.error('Error decoding recorded audio:', error);
                 }
 
-                // Stop all tracks
                 stream.getTracks().forEach(track => track.stop());
             };
 
             mediaRecorder.start();
-
         } catch (error) {
             console.error('Error accessing microphone:', error);
-            // Remove waiting state if microphone access fails
             recordButton.classList.remove('waiting');
 
-            // Show error messages for debugging
             if (error.name === 'NotAllowedError') {
                 alert('Microphone access denied. Please allow microphone access and try again.');
             } else if (error.name === 'NotFoundError') {
@@ -144,6 +145,7 @@ async function toggleRecording() {
             }
         }
     }
+
     function stopRecording() {
         if (mediaRecorder && isRecording) {
             mediaRecorder.stop();
@@ -162,11 +164,10 @@ async function toggleRecording() {
 }
 
 function handleRecordButtonTouch(event) {
-    event.preventDefault(); // Prevent default touch behavior
-    event.stopPropagation(); // Stop event bubbling
+    event.preventDefault();
+    event.stopPropagation();
     toggleRecording();
 }
-
 
 function handlePositionSliderChange(event) {
     if (audioContext && audioContext.state === 'suspended') {
@@ -187,18 +188,18 @@ function handlePositionSliderChange(event) {
 }
 
 function beginInteraction(x) {
-    isInteracting = true;
-    lastMouseX = x;
     if (audioContext && audioContext.state === 'suspended') {
         audioContext.resume();
     }
+
+    isInteracting = true;
+    lastMouseX = x;
 }
 
 function handleInteraction(x, width) {
     const last = Math.max(0, Math.min(1, lastMouseX / width));
     const current = Math.max(0, Math.min(1, x / width));
     const delta = last - current;
-
     playheadPosition += delta;
 
     samplerNode.port.postMessage({
@@ -232,7 +233,6 @@ function handleMouseMove(event) {
 
 function handleTouchStart(event) {
     event.preventDefault();
-
     const touch = event.touches[0];
     const rect = event.target.getBoundingClientRect();
     const x = touch.clientX - rect.left;
@@ -245,23 +245,20 @@ function handleTouchEnd(event) {
 }
 
 function handleTouchMove(event) {
-    event.preventDefault(); // Prevent default touch behavior like scrolling
+    event.preventDefault();
     if (!audioBuffer || !isInteracting) return;
 
     const touch = event.touches[0];
     const rect = event.target.getBoundingClientRect();
     const x = touch.clientX - rect.left;
-
     handleInteraction(x, rect.width);
 }
 
 async function init() {
-
     function generateSine(sampleRate = 44100) {
         const duration = 5; // seconds
         const frequency = 440; // Hz
         const amplitude = 0.5;
-
         const length = sampleRate * duration;
 
         audioBuffer = audioContext.createBuffer(1, length, sampleRate);
@@ -287,6 +284,7 @@ async function init() {
         samplerNode = new AudioWorkletNode(audioContext, 'sampler-processor');
         samplerNode.connect(audioContext.destination);
     }
+
     samplerNode.port.postMessage({
         action: 'setBuffer',
         buffer: channelData.buffer

--- a/src/main.js
+++ b/src/main.js
@@ -177,7 +177,7 @@ function handleInteraction(x, width) {
     //     action: 'updatePosition',
     //     position: position
     // });
-    
+
     const offset = position - 0.5; // Center the waveform around the interaction point
     offsetValue.textContent = offset.toFixed(2);
     waveform.plot(audioBuffer, offset);

--- a/src/main.js
+++ b/src/main.js
@@ -169,6 +169,15 @@ function beginInteraction() {
     }
 }
 
+function handleInteraction(x, width) {
+    const position = Math.max(0, Math.min(1, x / width));
+
+    samplerNode.port.postMessage({
+        action: 'updatePosition',
+        position: position
+    });
+}
+
 function handleMouseDown(event) {
     beginInteraction();
 }
@@ -205,15 +214,6 @@ function handleTouchMove(event) {
     const x = touch.clientX - rect.left;
 
     handleInteraction(x, rect.width);
-}
-
-function handleInteraction(x, width) {
-    const position = Math.max(0, Math.min(1, x / width));
-
-    samplerNode.port.postMessage({
-        action: 'updatePosition',
-        position: position
-    });
 }
 
 function handleOffsetChange(event) {

--- a/src/main.js
+++ b/src/main.js
@@ -253,7 +253,7 @@ function handleTouchMove(event) {
 }
 
 async function init() {
-    
+
     function generateSine(sampleRate = 44100) {
         const duration = 5; // seconds
         const frequency = 440; // Hz

--- a/src/main.js
+++ b/src/main.js
@@ -178,7 +178,7 @@ function handleInteraction(x, width) {
     //     position: position
     // });
 
-    const offset = position; // Center the waveform around the interaction point
+    const offset = position;
     offsetValue.textContent = offset.toFixed(2);
     waveform.plot(audioBuffer, offset);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -22,9 +22,9 @@ const recordButton = document.getElementById('recordButton');
 recordButton.addEventListener('click', toggleRecording);
 recordButton.addEventListener('touchstart', handleRecordButtonTouch);
 
-const offsetSlider = document.getElementById('offsetSlider');
-const offsetValue = document.getElementById('offsetValue');
-offsetSlider.addEventListener('input', handleOffsetChange);
+const positionSlider = document.getElementById('positionSlider');
+const positionSliderValue = document.getElementById('positionSliderValue');
+positionSlider.addEventListener('input', handlePositionSliderChange);
 
 document.getElementById(WAVEFORM_CANVAS_ID).addEventListener('mousedown', handleMouseDown);
 document.getElementById(WAVEFORM_CANVAS_ID).addEventListener('mousemove', handleWaveformMouseMove);
@@ -164,6 +164,25 @@ function handleRecordButtonTouch(event) {
     toggleRecording();
 }
 
+
+function handlePositionSliderChange(event) {
+    if (audioContext && audioContext.state === 'suspended') {
+        audioContext.resume();
+    }
+
+    const currentPosition = parseFloat(event.target.value);
+    positionSliderValue.textContent = currentPosition.toFixed(2);
+
+    samplerNode.port.postMessage({
+        action: 'updatePosition',
+        position: currentPosition
+    });
+
+    if (audioBuffer) {
+        waveform.plot(audioBuffer, currentPosition);
+    }
+}
+
 function beginInteraction(x) {
     isInteracting = true;
     lastX = x;
@@ -183,7 +202,7 @@ function handleInteraction(x, width) {
         position: currentPosition
     });
 
-    offsetValue.textContent = currentPosition.toFixed(2);
+    positionSliderValue.textContent = currentPosition.toFixed(2);
     waveform.plot(audioBuffer, currentPosition);
     lastX = x;
 }
@@ -231,15 +250,6 @@ function handleTouchMove(event) {
     const x = touch.clientX - rect.left;
 
     handleInteraction(x, rect.width);
-}
-
-function handleOffsetChange(event) {
-    const offset = parseFloat(event.target.value);
-    offsetValue.textContent = offset.toFixed(2);
-    
-    if (audioBuffer) {
-        waveform.plot(audioBuffer, offset);
-    }
 }
 
 async function init() {

--- a/src/main.js
+++ b/src/main.js
@@ -178,7 +178,7 @@ function handleInteraction(x, width) {
     //     position: position
     // });
 
-    const offset = position - 0.5; // Center the waveform around the interaction point
+    const offset = position; // Center the waveform around the interaction point
     offsetValue.textContent = offset.toFixed(2);
     waveform.plot(audioBuffer, offset);
 }

--- a/src/main.js
+++ b/src/main.js
@@ -163,14 +163,16 @@ function handleRecordButtonTouch(event) {
     toggleRecording();
 }
 
-function beginInteraction() {
+function beginInteraction(x) {
     isInteracting = true;
+    dragStartX = x;
     if (audioContext && audioContext.state === 'suspended') {
         audioContext.resume();
     }
 }
 
 function handleInteraction(x, width) {
+    const startPosition = dragStartX / width;
     const position = Math.max(0, Math.min(1, x / width));
 
     // samplerNode.port.postMessage({
@@ -178,13 +180,15 @@ function handleInteraction(x, width) {
     //     position: position
     // });
 
-    const offset = position;
+    const offset = startPosition - position;
     offsetValue.textContent = offset.toFixed(2);
     waveform.plot(audioBuffer, offset);
 }
 
 function handleMouseDown(event) {
-    beginInteraction();
+    const rect = event.target.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    beginInteraction(x);
 }
 
 function handleMouseUp(event) {
@@ -202,7 +206,12 @@ function handleWaveformMouseMove(event) {
 
 function handleTouchStart(event) {
     event.preventDefault();
-    beginInteraction();
+
+    const touch = event.touches[0];
+    const rect = event.target.getBoundingClientRect();
+    const x = touch.clientX - rect.left;
+
+    beginInteraction(x);
 }
 
 function handleTouchEnd(event) {

--- a/src/main.js
+++ b/src/main.js
@@ -13,6 +13,7 @@ let recordedChunks = [];
 let isRecording = false;
 
 let isInteracting = false;
+let dragStartX = null;
 
 document.addEventListener('dragover', (event) => { event.preventDefault(); });
 document.addEventListener('drop', handleDrop);
@@ -172,10 +173,14 @@ function beginInteraction() {
 function handleInteraction(x, width) {
     const position = Math.max(0, Math.min(1, x / width));
 
-    samplerNode.port.postMessage({
-        action: 'updatePosition',
-        position: position
-    });
+    // samplerNode.port.postMessage({
+    //     action: 'updatePosition',
+    //     position: position
+    // });
+    
+    const offset = position - 0.5; // Center the waveform around the interaction point
+    offsetValue.textContent = offset.toFixed(2);
+    waveform.plot(audioBuffer, offset);
 }
 
 function handleMouseDown(event) {

--- a/src/main.js
+++ b/src/main.js
@@ -20,6 +20,10 @@ const recordButton = document.getElementById('recordButton');
 recordButton.addEventListener('click', toggleRecording);
 recordButton.addEventListener('touchstart', handleRecordButtonTouch);
 
+const offsetSlider = document.getElementById('offsetSlider');
+const offsetValue = document.getElementById('offsetValue');
+offsetSlider.addEventListener('input', handleOffsetChange);
+
 document.getElementById(WAVEFORM_CANVAS_ID).addEventListener('mousedown', handleMouseDown);
 document.getElementById(WAVEFORM_CANVAS_ID).addEventListener('mousemove', handleWaveformMouseMove);
 document.addEventListener('mouseup', handleMouseUp); // pick up mouseUp anywhere
@@ -214,7 +218,17 @@ function updateWaveformPosition(x, width) {
     waveform.updatePlayhead(position);
 }
 
+function handleOffsetChange(event) {
+    const offset = parseFloat(event.target.value);
+    offsetValue.textContent = offset.toFixed(2);
+    
+    if (audioBuffer) {
+        waveform.plot(audioBuffer, offset);
+    }
+}
+
 async function init() {
+    
     function generateSine(sampleRate = 44100) {
         const duration = 5; // seconds
         const frequency = 440; // Hz

--- a/src/sampler.js
+++ b/src/sampler.js
@@ -20,7 +20,7 @@ class SamplerProcessor extends AudioWorkletProcessor {
 
         if (action === 'updatePosition') {
             if (this.buffer) {
-                this.targetPosition += (position * (this.buffer.length - 1) - this.targetPosition) * 0.4;
+                this.targetPosition = position * (this.buffer.length - 1);
 
                 this.isPlaying = true;
             }

--- a/src/sampler.js
+++ b/src/sampler.js
@@ -20,7 +20,7 @@ class SamplerProcessor extends AudioWorkletProcessor {
 
         if (action === 'updatePosition') {
             if (this.buffer) {
-                this.targetPosition += (position * (this.buffer.length - 1) - this.targetPosition) * 0.1;
+                this.targetPosition += (position * (this.buffer.length - 1) - this.targetPosition) * 0.4;
 
                 this.isPlaying = true;
             }

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -4,6 +4,7 @@ export class Waveform {
         this.ctx = this.canvas.getContext('2d');
         this.playhead = document.getElementById(playheadId);
         this.currentBuffer = null;
+        this.position = 0;
         this.upscaleFactor = 4;
         this.updateCanvasSize();
 
@@ -20,7 +21,7 @@ export class Waveform {
 
     handleResize() {
         if (this.currentBuffer) {
-            this.plot(this.currentBuffer);
+            this.plot(this.currentBuffer, this.position);
         } else {
             this.updateCanvasSize();
         }
@@ -29,6 +30,7 @@ export class Waveform {
     plot(buffer, position = 0) {
         if (!buffer || buffer.numberOfChannels < 1) return;
         this.currentBuffer = buffer;
+        this.position = position;
         this.updateCanvasSize();
 
         const channelData = buffer.getChannelData(0); // Use the first channel

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -27,6 +27,7 @@ export class Waveform {
     }
 
     plot(buffer, offset = 0) {
+        console.log(offset);
         if (!buffer || buffer.numberOfChannels < 1) return;
         this.currentBuffer = buffer;
         this.updateCanvasSize();

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -35,11 +35,11 @@ export class Waveform {
         const dataLength = channelData.length;
         const amp = this.canvasHeight / 2;
         const upscaledWidth = this.canvasWidth * this.upscaleFactor;
-        
+
         const waveformPoints = [];
         for (let i = 0; i < upscaledWidth; i++) {
             const samplePosition = (i * dataLength) / upscaledWidth;
-            
+
             let sample;
             if (samplePosition <= 0) {
                 sample = channelData[0] || 0;
@@ -53,10 +53,10 @@ export class Waveform {
                 const upperSample = channelData[upperIndex] || 0;
                 sample = lowerSample + (upperSample - lowerSample) * fraction;
             }
-            
+
             waveformPoints.push(sample);
         }
-        
+
 
         this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
         this.ctx.strokeStyle = 'black';
@@ -67,24 +67,24 @@ export class Waveform {
         for (let i = 0; i < this.canvasWidth; i++) {
             const startIdx = Math.floor((i * upscaledWidth) / this.canvasWidth);
             const endIdx = Math.floor(((i + 1) * upscaledWidth) / this.canvasWidth);
-            
+
             let min = 0, max = 0;
             for (let j = startIdx; j < endIdx && j < waveformPoints.length; j++) {
                 const value = waveformPoints[j];
                 if (value < min) min = value;
                 if (value > max) max = value;
             }
-            
+
             const x = i;
             const yMin = amp + (min * amp);
             const yMax = amp + (max * amp);
-            
+
             if (i === 0) {
                 this.ctx.moveTo(x, yMax);
             } else {
                 this.ctx.lineTo(x, yMax);
             }
-            
+
             if (Math.abs(yMax - yMin) > 1) {
                 this.ctx.lineTo(x, yMin);
                 this.ctx.lineTo(x, yMax);

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -41,11 +41,11 @@ export class Waveform {
         this.ctx.lineWidth = 1;
         this.ctx.lineCap = 'round';
 
-        const highResWidth = this.canvasWidth * this.upscaleFactor;
+        const upscaledWidth = this.canvasWidth * this.upscaleFactor;
         
         const waveformPoints = [];
-        for (let i = 0; i < highResWidth; i++) {
-            const samplePosition = (i * dataLength) / highResWidth;
+        for (let i = 0; i < upscaledWidth; i++) {
+            const samplePosition = (i * dataLength) / upscaledWidth;
             
             let sample;
             if (samplePosition >= dataLength - 1) {
@@ -66,8 +66,8 @@ export class Waveform {
         
         this.ctx.beginPath();
         for (let i = 0; i < this.canvasWidth; i++) {
-            const startIdx = Math.floor((i * highResWidth) / this.canvasWidth);
-            const endIdx = Math.floor(((i + 1) * highResWidth) / this.canvasWidth);
+            const startIdx = Math.floor((i * upscaledWidth) / this.canvasWidth);
+            const endIdx = Math.floor(((i + 1) * upscaledWidth) / this.canvasWidth);
             
             let min = 0, max = 0;
             for (let j = startIdx; j < endIdx && j < waveformPoints.length; j++) {

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -26,7 +26,7 @@ export class Waveform {
         }
     }
 
-    plot(buffer, offset = 0.5) {
+    plot(buffer, offset = 0) {
         if (!buffer || buffer.numberOfChannels < 1) return;
         this.currentBuffer = buffer;
         this.updateCanvasSize();
@@ -62,13 +62,13 @@ export class Waveform {
         this.ctx.strokeStyle = 'black';
         this.ctx.lineWidth = 1;
         this.ctx.lineCap = 'round';
-        
+
         this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
         this.ctx.beginPath();
 
         for (let i = 0; i < this.canvasWidth; i++) {
-            const startIdx = Math.floor((i * upscaledWidth) / this.canvasWidth);
-            const endIdx = Math.floor(((i + 1) * upscaledWidth) / this.canvasWidth);
+            const startIdx = Math.floor((i * upscaledWidth) / this.canvasWidth + Math.floor(offset * upscaledWidth));
+            const endIdx = Math.floor(((i + 1) * upscaledWidth) / this.canvasWidth + Math.floor(offset * upscaledWidth));
 
             let min = 0, max = 0;
             for (let j = startIdx; j < endIdx && j < waveformPoints.length; j++) {

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -41,10 +41,10 @@ export class Waveform {
             const samplePosition = (i * dataLength) / upscaledWidth;
             
             let sample;
-            if (samplePosition >= dataLength - 1) {
-                sample = channelData[dataLength - 1] || 0;
-            } else if (samplePosition <= 0) {
+            if (samplePosition <= 0) {
                 sample = channelData[0] || 0;
+            } else if (samplePosition >= dataLength - 1) {
+                sample = channelData[dataLength - 1] || 0;
             } else {
                 const lowerIndex = Math.floor(samplePosition);
                 const upperIndex = Math.ceil(samplePosition);

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -67,6 +67,8 @@ export class Waveform {
         this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
         this.ctx.beginPath();
 
+        offset -= 0.5;
+
         for (let i = 0; i < this.canvasWidth; i++) {
             const startIdx = Math.floor((i * upscaledWidth) / this.canvasWidth + Math.floor(offset * upscaledWidth));
             const endIdx = Math.floor(((i + 1) * upscaledWidth) / this.canvasWidth + Math.floor(offset * upscaledWidth));

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -4,10 +4,9 @@ export class Waveform {
         this.ctx = this.canvas.getContext('2d');
         this.playhead = document.getElementById(playheadId);
         this.currentBuffer = null;
-        this.position = 0;
+        this.playheadPosition = 0;
         this.upscaleFactor = 4;
         this.updateCanvasSize();
-
         window.addEventListener('resize', () => this.handleResize());
     }
 
@@ -21,7 +20,7 @@ export class Waveform {
 
     handleResize() {
         if (this.currentBuffer) {
-            this.plot(this.currentBuffer, this.position);
+            this.plot(this.currentBuffer, this.playheadPosition);
         } else {
             this.updateCanvasSize();
         }
@@ -29,13 +28,13 @@ export class Waveform {
 
     plot(buffer, position = 0) {
         if (!buffer || buffer.numberOfChannels < 1) return;
+
         this.currentBuffer = buffer;
-        this.position = position;
+        this.playheadPosition = position;
         this.updateCanvasSize();
 
         const channelData = buffer.getChannelData(0); // Use the first channel
         const dataLength = channelData.length;
-
         const amp = this.canvasHeight / 2;
         const upscaledWidth = this.canvasWidth * this.upscaleFactor;
         const samplesPerPixel = dataLength / upscaledWidth;
@@ -64,11 +63,10 @@ export class Waveform {
         this.ctx.strokeStyle = 'black';
         this.ctx.lineWidth = 1;
         this.ctx.lineCap = 'round';
-
         this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
         this.ctx.beginPath();
 
-        position -= 0.5; // waveform is normally centered so we need to "rewind" a half of it
+        position -= 0.5; // waveform is normally centered in the middle so we need to "rewind" a half of it
 
         for (let i = 0; i < this.canvasWidth; i++) {
             const startIdx = Math.floor((i * upscaledWidth) / this.canvasWidth + Math.floor(position * upscaledWidth));

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -27,6 +27,8 @@ export class Waveform {
     }
 
     plot(buffer, offset = 0) {
+        // * @param {number} offset (x axis), relative to the center of the canvas
+        // 0 aligns the start, 1 aligns the end of the waveform 
         console.log(offset);
         if (!buffer || buffer.numberOfChannels < 1) return;
         this.currentBuffer = buffer;

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -26,10 +26,7 @@ export class Waveform {
         }
     }
 
-    plot(buffer, offset = 0) {
-        // * @param {number} offset (x axis)
-        // relative to the center of the canvas and normalised to file length
-        // 0 aligns the start, 1 aligns the end of the waveform 
+    plot(buffer, position = 0) {
         if (!buffer || buffer.numberOfChannels < 1) return;
         this.currentBuffer = buffer;
         this.updateCanvasSize();
@@ -69,11 +66,11 @@ export class Waveform {
         this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
         this.ctx.beginPath();
 
-        offset -= 0.5; // waveform is normally centered so we need to "rewind" a half of it
+        position -= 0.5; // waveform is normally centered so we need to "rewind" a half of it
 
         for (let i = 0; i < this.canvasWidth; i++) {
-            const startIdx = Math.floor((i * upscaledWidth) / this.canvasWidth + Math.floor(offset * upscaledWidth));
-            const endIdx = Math.floor(((i + 1) * upscaledWidth) / this.canvasWidth + Math.floor(offset * upscaledWidth));
+            const startIdx = Math.floor((i * upscaledWidth) / this.canvasWidth + Math.floor(position * upscaledWidth));
+            const endIdx = Math.floor(((i + 1) * upscaledWidth) / this.canvasWidth + Math.floor(position * upscaledWidth));
 
             let min = 0, max = 0;
             for (let j = startIdx; j < endIdx && j < waveformPoints.length; j++) {

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -35,12 +35,6 @@ export class Waveform {
         const dataLength = channelData.length;
         const amp = this.canvasHeight / 2;
 
-        this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
-
-        this.ctx.strokeStyle = 'black';
-        this.ctx.lineWidth = 1;
-        this.ctx.lineCap = 'round';
-
         const upscaledWidth = this.canvasWidth * this.upscaleFactor;
         
         const waveformPoints = [];
@@ -63,6 +57,12 @@ export class Waveform {
             
             waveformPoints.push(sample);
         }
+        
+
+        this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
+        this.ctx.strokeStyle = 'black';
+        this.ctx.lineWidth = 1;
+        this.ctx.lineCap = 'round';
         
         this.ctx.beginPath();
         for (let i = 0; i < this.canvasWidth; i++) {

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -27,14 +27,13 @@ export class Waveform {
     }
 
     plot(buffer) {
-        this.currentBuffer = buffer; // Store buffer for potential replotting
+        if (!buffer || buffer.numberOfChannels < 1) return;
+        this.currentBuffer = buffer;
         this.updateCanvasSize();
 
-        if (!buffer || buffer.numberOfChannels < 1) return;
         const channelData = buffer.getChannelData(0); // Use the first channel
         const dataLength = channelData.length;
         const amp = this.canvasHeight / 2;
-
         const upscaledWidth = this.canvasWidth * this.upscaleFactor;
         
         const waveformPoints = [];
@@ -63,7 +62,7 @@ export class Waveform {
         this.ctx.strokeStyle = 'black';
         this.ctx.lineWidth = 1;
         this.ctx.lineCap = 'round';
-        
+
         this.ctx.beginPath();
         for (let i = 0; i < this.canvasWidth; i++) {
             const startIdx = Math.floor((i * upscaledWidth) / this.canvasWidth);

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -26,7 +26,7 @@ export class Waveform {
         }
     }
 
-    plot(buffer) {
+    plot(buffer, offset = 0.5) {
         if (!buffer || buffer.numberOfChannels < 1) return;
         this.currentBuffer = buffer;
         this.updateCanvasSize();
@@ -59,11 +59,11 @@ export class Waveform {
             waveformPoints.push(sample);
         }
 
-        this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
         this.ctx.strokeStyle = 'black';
         this.ctx.lineWidth = 1;
         this.ctx.lineCap = 'round';
-
+        
+        this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
         this.ctx.beginPath();
 
         for (let i = 0; i < this.canvasWidth; i++) {

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -33,6 +33,7 @@ export class Waveform {
 
         const channelData = buffer.getChannelData(0); // Use the first channel
         const dataLength = channelData.length;
+
         const amp = this.canvasHeight / 2;
         const upscaledWidth = this.canvasWidth * this.upscaleFactor;
 
@@ -57,13 +58,13 @@ export class Waveform {
             waveformPoints.push(sample);
         }
 
-
         this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
         this.ctx.strokeStyle = 'black';
         this.ctx.lineWidth = 1;
         this.ctx.lineCap = 'round';
 
         this.ctx.beginPath();
+
         for (let i = 0; i < this.canvasWidth; i++) {
             const startIdx = Math.floor((i * upscaledWidth) / this.canvasWidth);
             const endIdx = Math.floor(((i + 1) * upscaledWidth) / this.canvasWidth);

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -27,7 +27,8 @@ export class Waveform {
     }
 
     plot(buffer, offset = 0) {
-        // * @param {number} offset (x axis), relative to the center of the canvas
+        // * @param {number} offset (x axis)
+        // relative to the center of the canvas and normalised to file length
         // 0 aligns the start, 1 aligns the end of the waveform 
         console.log(offset);
         if (!buffer || buffer.numberOfChannels < 1) return;
@@ -69,7 +70,7 @@ export class Waveform {
         this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight);
         this.ctx.beginPath();
 
-        offset -= 0.5;
+        offset -= 0.5; // waveform is normally centered so we need to "rewind" a half of it
 
         for (let i = 0; i < this.canvasWidth; i++) {
             const startIdx = Math.floor((i * upscaledWidth) / this.canvasWidth + Math.floor(offset * upscaledWidth));

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -101,9 +101,4 @@ export class Waveform {
 
         this.ctx.stroke();
     }
-
-    updatePlayhead(progress) {
-        const playheadX = Math.max(0, Math.min(1, progress)) * this.canvasWidth;
-        if (this.playhead) this.playhead.style.transform = `translateX(${playheadX}px)`;
-    }
 }

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -36,10 +36,11 @@ export class Waveform {
 
         const amp = this.canvasHeight / 2;
         const upscaledWidth = this.canvasWidth * this.upscaleFactor;
+        const samplesPerPixel = dataLength / upscaledWidth;
 
         const waveformPoints = [];
         for (let i = 0; i < upscaledWidth; i++) {
-            const samplePosition = (i * dataLength) / upscaledWidth;
+            const samplePosition = i * samplesPerPixel;
 
             let sample;
             if (samplePosition <= 0) {

--- a/src/waveform.js
+++ b/src/waveform.js
@@ -30,7 +30,6 @@ export class Waveform {
         // * @param {number} offset (x axis)
         // relative to the center of the canvas and normalised to file length
         // 0 aligns the start, 1 aligns the end of the waveform 
-        console.log(offset);
         if (!buffer || buffer.numberOfChannels < 1) return;
         this.currentBuffer = buffer;
         this.updateCanvasSize();


### PR DESCRIPTION
New UX!

Playback is now caused by dragging the waveform and the playhead is fixed in the middle.

Added slider for tracking the position in the file, with [0, 1] normalised to the start and end of the file.
Adjusting the slider also causes playback, at least for now.

Removed smoothing of targetPosition since scrubbing from right to left while at the end of the file (currentPosition: 1) would cause playback, which did not correspond with the silence plotted on the right hand side.